### PR TITLE
Add chinese translation

### DIFF
--- a/i18n/i18n.js
+++ b/i18n/i18n.js
@@ -20,29 +20,33 @@ import bn from "./translations/bn.json";
 import hi from "./translations/hi.json";
 import id from "./translations/id.json";
 import zh from "./translations/zh.json";
+import zh_CN from "./translations/zh_CN.json";
+import zh_TW from "./translations/zh_TW.json";
 
 i18n.fallbacks = true;
 i18n.translations = {
-  en,
-  pl,
-  ru,
-  th,
-  pt_BR,
-  sr,
-  ja,
-  de,
-  nl,
-  sk,
-  es,
-  it,
-  hu,
-  fr,
-  cz,
-  ar,
-  bn,
-  hi,
-  id,
-  zh
+  en: en,
+  pl: pl,
+  ru: ru,
+  th: th,
+  pt_BR: pt_BR,
+  sr: sr,
+  ja: ja,
+  de: de,
+  nl: nl,
+  sk: sk,
+  es: es,
+  it: it,
+  hu: hu,
+  fr: fr,
+  cz: cz,
+  ar: ar,
+  bn: bn,
+  hi: hi,
+  id: id,
+  zh: zh,
+  "zh_Hans-CN": zh_CN,
+  "zh-Hant-TW": zh_TW
 };
 i18n.locale = Localization.locale;
 i18n.defaultLocale = "en-EN";

--- a/i18n/i18n.js
+++ b/i18n/i18n.js
@@ -1,27 +1,49 @@
-import * as Localization from 'expo-localization';
-import i18n from 'i18n-js';
-import en from './translations/en.json';
-import pl from './translations/pl.json';
-import pt_BR from './translations/pt_BR.json';
-import th from './translations/th.json';
-import ru from './translations/ru.json';
+import * as Localization from "expo-localization";
+import i18n from "i18n-js";
+import en from "./translations/en.json";
+import pl from "./translations/pl.json";
+import pt_BR from "./translations/pt_BR.json";
+import th from "./translations/th.json";
+import ru from "./translations/ru.json";
 import sr from "./translations/sr.json";
 import ja from "./translations/ja.json";
 import de from "./translations/de.json";
 import nl from "./translations/nl.json";
 import sk from "./translations/sk.json";
 import es from "./translations/es.json";
-import it from './translations/it.json';
-import hu from './translations/hu.json';
-import fr from './translations/fr.json';
-import cz from './translations/cz.json';
-import ar from './translations/ar.json';
-import bn from './translations/bn.json';
+import it from "./translations/it.json";
+import hu from "./translations/hu.json";
+import fr from "./translations/fr.json";
+import cz from "./translations/cz.json";
+import ar from "./translations/ar.json";
+import bn from "./translations/bn.json";
 import hi from "./translations/hi.json";
 import id from "./translations/id.json";
+import zh from "./translations/zh.json";
 
 i18n.fallbacks = true;
-i18n.translations = { en, pl, ru, th, pt_BR, sr, ja, de, nl, sk, es, it, hu, fr, cz, ar, bn, hi, id };
+i18n.translations = {
+  en,
+  pl,
+  ru,
+  th,
+  pt_BR,
+  sr,
+  ja,
+  de,
+  nl,
+  sk,
+  es,
+  it,
+  hu,
+  fr,
+  cz,
+  ar,
+  bn,
+  hi,
+  id,
+  zh
+};
 i18n.locale = Localization.locale;
 i18n.defaultLocale = "en-EN";
 

--- a/i18n/translations/zh.json
+++ b/i18n/translations/zh.json
@@ -1,0 +1,12 @@
+{
+  "tracing_paper": "描图纸",
+  "tracing_paper_help": "把一个图片复制到物理的纸。用一个图片当模板。转并缩放到完美的对准。锁好屏幕以后，把描图纸放在手机屏幕的上面并开始画画。",
+  "privacy_policy": "隐私政策",
+  "licenses_credits": "许可, 贡献者名单",
+  "pick_a_image": "选择图片",
+  "camera": "相机",
+  "toast_screen_locked": "屏幕已锁",
+  "toast_screen_unlocked": "屏幕已开锁",
+  "toast_image_loaded": "图片已加载",
+  "toast_no_access_to_camera": "没有相机存取"
+}

--- a/i18n/translations/zh_CN.json
+++ b/i18n/translations/zh_CN.json
@@ -1,0 +1,12 @@
+{
+  "tracing_paper": "描图纸",
+  "tracing_paper_help": "把一个图片复制到物理的纸。用一个图片当模板。转并缩放到完美的对准。锁好屏幕以后，把描图纸放在手机屏幕的上面并开始画画。",
+  "privacy_policy": "隐私政策",
+  "licenses_credits": "许可, 贡献者名单",
+  "pick_a_image": "选择图片",
+  "camera": "相机",
+  "toast_screen_locked": "屏幕已锁",
+  "toast_screen_unlocked": "屏幕已开锁",
+  "toast_image_loaded": "图片已加载",
+  "toast_no_access_to_camera": "没有相机存取"
+}

--- a/i18n/translations/zh_TW.json
+++ b/i18n/translations/zh_TW.json
@@ -1,0 +1,12 @@
+{
+  "tracing_paper": "描圖紙",
+  "tracing_paper_help": "把一個圖片複製到物理的紙。用一個圖片當模板。轉並縮放到完美的對準。鎖好屏幕以後，把描圖紙放在手機屏幕的上面並開始畫畫。",
+  "privacy_policy": "隱私政策",
+  "licenses_credits": "許可, 貢獻者名單",
+  "pick_a_image": "選擇圖片",
+  "camera": "相機",
+  "toast_screen_locked": "屏幕已鎖",
+  "toast_screen_unlocked": "屏幕已開锁",
+  "toast_image_loaded": "圖片已加載",
+  "toast_no_access_to_camera": "沒有相機存取"
+}


### PR DESCRIPTION
Closes #42 

Notes: 

- The quote changes come from [Prettier's](https://prettier.io/) default settings. Feel free to keep this change or revert to single quotes.
- In order for both simplified and traditional variants of Chinese to be correctly picked up, I had to add the locale names to the `i18n.translations` object for all locales.
- Tested successfully on an Android emulator running Android 10 in Simplified Chinese for China (简体中文(中国)) and Traditional Chinese for Taiwan (繁體中文(台灣))
- When running the app, I noticed that some buttons were not being translated. I created #56 to fix that issue. It's a very easy fix and may be a good candidate for Hacktoberfest as well. Unfortunately, getting translations the missing strings in all languages might prove more difficult than fixing the underlying issue.
