### PR TITLE
adding lib to handle monochrome image filter. adding monochrome button

### DIFF
--- a/App.js
+++ b/App.js
@@ -23,6 +23,7 @@ export default class App extends React.Component {
     photoLoader: false,
     mirror: false,
     brightness: false,
+    monochrome: false,
   };
 
   constructor(props) {
@@ -31,7 +32,7 @@ export default class App extends React.Component {
   }
 
   render() {
-    let { image, width, height, locked, help, camera, photoLoader, mirror, brightness } = this.state;
+    let { image, width, height, locked, help, camera, photoLoader, mirror, brightness, monochrome } = this.state;
 
     if (help) {
       return (
@@ -84,13 +85,14 @@ export default class App extends React.Component {
     } else {
       return (
         <View style={{ flex: 1, backgroundColor: 'black' }}>
-          <TrasformableImage mirror={mirror} image={image} width={width} height={height} locked={locked} />
+          <TrasformableImage mirror={mirror} image={image} width={width} height={height} locked={locked} monochrome={monochrome} />
           {!locked &&
             <FloatingToolbar top={true} left={true}>
               <ActionButton onPress={this._resetImage} text={i18n.t("button_back")} textPosition="right" iconName="md-arrow-back" />
             </FloatingToolbar>
           }
           <FloatingToolbar left={true}>
+            {!locked && <ActionButton onPress={this._monochrome} text={i18n.t("button_monochrome")} textPosition="right" iconName="md-sunny" />}
             {!locked && <ActionButton onPress={this._brightness} text={i18n.t("button_brightness")} textPosition="right" iconName="md-sunny" />}
             {!locked && <ActionButton onPress={this._mirror} text={i18n.t("button_mirror")} textPosition="right" iconName="md-repeat" />}
           </FloatingToolbar>
@@ -110,6 +112,10 @@ export default class App extends React.Component {
       await Brightness.useSystemBrightnessAsync();
     }
     this.state.brightness ? this.setState({ brightness: false }) : this.setState({ brightness: true });
+  }
+
+  _monochrome = () => {
+    this.state.monochrome ? this.setState({ monochrome: false }) : this.setState({ monochrome: true });
   }
 
   _mirror = () => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "16.8.3",
     "react-dom": "^16.8.6",
     "react-native": "https://github.com/expo/react-native/archive/sdk-34.0.0.tar.gz",
+    "react-native-color-matrix-image-filters": "^5.2.0",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-web": "^0.11.4"
   },

--- a/transformable-image.js
+++ b/transformable-image.js
@@ -8,6 +8,7 @@ import {
   State,
 } from 'react-native-gesture-handler';
 import Styles from './styles'
+import { Grayscale } from 'react-native-color-matrix-image-filters';
 
 export default class TransformableImage extends React.Component {
   panRef = React.createRef();
@@ -91,6 +92,23 @@ export default class TransformableImage extends React.Component {
     }
   };
 
+  renderImage(transform) {
+    const { monochrome, image } = this.props;
+    const Image = () => (
+      <Animated.Image
+        style={[
+          { width: this._width, height: this._height },
+          { transform },
+        ]}
+        source={{ uri: image }}
+      />
+    )
+    if ( monochrome ) {
+      return <Grayscale>{Image()}</Grayscale>;
+    }
+    return Image();
+  }
+
   render() {
     let transform = [
       { perspective: 200 },
@@ -126,13 +144,7 @@ export default class TransformableImage extends React.Component {
                 onHandlerStateChange={this._onPinchHandlerStateChange}>
                 <Animated.View style={styles.container} collapsable={false}>
                   {this.props.image &&
-                    <Animated.Image
-                      style={[
-                        { width: this._width, height: this._height },
-                        { transform },
-                      ]}
-                      source={{ uri: this.props.image }}
-                    />
+                    this.renderImage(transform)
                   }
                 </Animated.View>
               </PinchGestureHandler>


### PR DESCRIPTION
PR for https://github.com/dodie/tracing-paper-sketching/issues/61

react-native-color-matrix-image-filters will handle converting the image to monochrome (https://github.com/iyegoroff/react-native-color-matrix-image-filters)

I added the button but currently using the same icon as the brightness button (which wasnt in your screenshot of the issue so I just left the monochrome button above this one).